### PR TITLE
Make starting map coordinates configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
+# Override mesh node to query for information
 MESH_INFO_LOCAL_NODE="localnode.local.mesh"
+# Set default map view
+MESH_INFO_MAP_LATITUDE=37.405
+MESH_INFO_MAP_LONGITUDE=-98.525
+MESH_INFO_MAP_ZOOM=5
 MESH_INFO_LOG_LEVEL="INFO"
 MESH_INFO_DATA_DIR="/var/lib/mesh-info"
 MESH_INFO_DB_URL="postgresql+psycopg2://postgres:postgres@localhost:5432/postgres"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Added
 * Basic implementation of network map.
   Client is required internet access to fetch tiles.
   All map elements rendered on single layer.
+* Set starting map coordinates via configuration file (`#45 <https://github.com/smsearcy/mesh-info/issues/45>`_)
 
 Changed
 ^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Mesh Info
 Collects information about an `AREDN <https://arednmesh.org/>`_ mesh network,
 tracking and graphing historical data such as link quality and cost.
 
-Inspired by based on KG6WXC's `MeshMap`_,
+Inspired by and based on  KG6WXC's `MeshMap`_,
 but redesigned for tracking the historical data.
 
 Uses Python's `asyncio` library to concurrently query nodes for faster polling times.
@@ -43,14 +43,17 @@ rather than re-inventing the wheel.
 While I was thinking of keeping the same database design
 (so this could be a drop-in replacement for the mapper)
 I've decided to initially focus on storing historical time-series data and
-will be working on map visualization after that.
+then started adding some basic map visualizations.
 
 
 Acknowledgements
 ----------------
 
-As mentioned above, this is based on the work done by Eric (KG6WXC),
+As mentioned above,
+this is based on the work done by Eric (KG6WXC),
 who has been very helpful when I had questions.
+Besides learning that I could get all the nodes from OLSR and about AREDN's ``sysinfo.json``,
+the map uses his icons and much of the Javascript is based on what he did.
 
 Project icon is from `here <https://commons.wikimedia.org/wiki/File:FullMeshNetwork.svg>`_.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,78 @@
+Configuration
+=============
+
+*Mesh Info* is configured via an environment file named ``.env`` in the same folder as the project was cloned into.
+If you followed the :doc:`installation instructions <installation>` then it should be ``/opt/mesh-info/src/.env``.
+
+Example
+-------
+
+.. code-block:: ini
+
+   MESH_INFO_LOCAL_NODE="10.1.1.1"
+   MESH_INFO_MAP_LATITUDE="37.405"
+   MESH_INFO_MAP_LONGITUDE="-98.525"
+   MESH_INFO_MAP_ZOOM="5"
+   MESH_INFO_LOG_LEVEL=INFO
+   MESH_INFO_DB_URL="postgresql+psycopg2://postgres:password@localhost:5432/postgres"
+
+
+Options
+-------
+
+MESH_INFO_LOCAL_NODE
+   Specify the node name or IP address to connect to for OLSR information.
+   Useful if *Mesh Info* server cannot resolve default of `localnode.local.mesh`.
+
+MESH_INFO_MAP_LATITUDE
+   Latitude coordinate to center map on.
+
+MESH_INFO_MAP_LATITUDE
+   Longitude coordinate to center map on.
+
+MESH_INFO_MAP_ZOOM
+   Default zoom level.
+   Passed to `Leaflet <https://leafletjs.com/>`_.
+   General range is 2 (whole world) to 16 (several blocks?).
+
+MESH_INFO_LOG_LEVEL
+   Controls how much information is logged/displayed in terminal.
+   Can be one of the following (from most verbose to least):
+   ``TRACE``, ``DEBUG``, ``INFO``, ``SUCCESS``, ``WARNING``, ``ERROR``.
+   Default is ``SUCCESS``.
+
+MESH_INFO_WEB_BIND
+   TCP or Unix socket to bind web application to.
+   Defaults to ``0.0.0.0:8000``.
+   A Unix socket looks like ``unix:/run/mesh-info.sock``.
+
+MESH_INFO_COLLECTOR_NODE_INACTIVE
+   Number of days a node remains on the map in inactive state after it was last seen.
+   Default is 7 days.
+
+MESH_INFO_COLLECTOR_LINK_INACTIVE
+   Number of days a link remains on the map in inactive state after it was last seen.
+   Default is 1 day.
+
+MESH_INFO_POLLER_MAX_CONNECTIONS
+   Maximum number of simultaneous outgoing polling connections.
+   Default is 50.
+
+MESH_INFO_POLLER_CONNECT_TIMEOUT
+   Number of seconds to establish a connection to a node when polling the network.
+   Decrease to speed up network polling at the risk of having more nodes timeout.
+   Default is 10.
+
+MESH_INFO_POLLER_READ_TIMEOUT
+   Number of seconds to read data from node before timing out.
+   Decrease to speed up network polling at the risk of having more nodes timeout.
+   Default is 15.
+
+MESH_INFO_DB_URL
+   Override the default SQLite database by pointing to a PostgreSQL server
+   (or changing the default location).
+
+MESH_INFO_ENVIRONMENT
+   Either ``production`` or ``development``.
+   Defaults to ``production``, use ``development`` to enable more debugging options.
+   See :doc:`contributing` for more information.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -37,10 +37,6 @@ Then, setup the Python virtual environment:
     (venv) $ pip install -r dev-requirements.txt -r requirements.txt
     (venv) $ pip install -e .
     (venv) $ make migrate-db
-    # run the test suite locally
-    (venv) $ make
-    # run web service with development settings
-    (venv) $ make web
 
 Create a ``.env`` file in the ``mesh-info`` folder and add:
 
@@ -56,6 +52,52 @@ Create a ``.env`` file in the ``mesh-info`` folder and add:
 
     Setting the environment to ``development`` enables the Pyramid web framework's debug toolbar
     and puts the data directories in the current user's home folder.
+
+To get data, either run ``meshinfo collector``
+or use ``meshinfo import`` to import data.
+
+Run the development web server via:
+
+.. code-block:: console
+
+   (venv) $ ./dev-web.sh
+
+Connect to the server at http://localhost:8000.
+
+
+Testing
+-------
+
+There is a ``Makefile`` with some commonly used commands and tests.
+Run ``make`` to run the general test suite.
+
+make pre-commit
+   Runs `pre-commit <https://pre-commit.com/>`_ to check/format files.
+
+make lint
+   Runs `Flake8 <https://flake8.pycqa.org/en/latest/index.html>`_ to do static linting.
+
+make mypy
+   Run `mypy <http://mypy-lang.org/>`_ static type checker.
+
+make tests
+   Run test suite.
+
+   .. tip::
+
+      Copy ``sysinfo.json`` samples into ``tests/data`` to verify they can be successfully parsed.
+
+make docs
+   Generate HTML documentation locally via `Sphinx <https://www.sphinx-doc.org/>`_.
+
+make make-migration
+   Create new database migrations via `Alembic <https://alembic.sqlalchemy.org/>`_.
+
+make migrate-db
+   Apply `Alembic <https://alembic.sqlalchemy.org/>`_ database migrations.
+
+make requirements
+   Generate requirements files via `pip-tools <https://pypi.org/project/pip-tools/>`_.
 
 
 Architecture

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Mesh Info: AREDN Network Information
 
    guide
    installation
+   config
    commands
    contributing
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,7 +34,7 @@ and create ``/var/lib/mesh-info`` for storing the application data.
     (mesh-info) $ pip install -r /opt/mesh-info/src/requirements.txt
     (mesh-info) $ pip install -e /opt/mesh-info/src
     # Run the database migrations
-    (mesh-info) $ alembic upgrade head
+    (mesh-info) $ alembic -c /opt/mesh-info/src/alembic.ini upgrade head
     (mesh-info) $ deactivate
     $ exit
 
@@ -56,7 +56,9 @@ for the collector service to run:
 
     MESH_INFO_LOCAL_NODE="10.1.1.1"
 
-*TODO: Document the rest of the configuration options in a "Configuration" section.*
+.. tip::
+
+   See :doc:`config` for more details and options.
 
 You can also do a test of the poller/collector to confirm database access and data folder.
 The ``--run-once`` option means it will poll the network once, save the results, and quit.
@@ -213,7 +215,7 @@ To get the latest version of Mesh Info, run the following:
     $ sudo systemctl stop meshinfo-web meshinfo-collector
     $ cd /opt/mesh-info/src
     $ sudo -u meshinfo git pull
-    $ sudo -u meshinfo /opt/mesh-info/bin/alembic upgrade head
+    $ sudo -u meshinfo /opt/mesh-info/bin/alembic -c /opt/mesh-info/src/alembic.ini upgrade head
     $ sudo systemctl restart meshinfo-web meshinfo-collector
 
 .. warning::

--- a/meshinfo/config.py
+++ b/meshinfo/config.py
@@ -57,6 +57,12 @@ class AppConfig:
         pool_pre_ping: bool = environ.bool_var(default=True)
 
     @environ.config
+    class Map:
+        latitude: float = environ.var(default=19.64, converter=float)
+        longitude: float = environ.var(default=-1.58, converter=float)
+        zoom: int = environ.var(default=3, converter=int)
+
+    @environ.config
     class Poller:
         max_connections: int = environ.var(default=50, converter=int)
         connect_timeout: int = environ.var(default=10, converter=int)
@@ -77,6 +83,7 @@ class AppConfig:
     aredn: Aredn = environ.group(Aredn)
     collector: Collector = environ.group(Collector)
     db: DB = environ.group(DB)
+    map: Map = environ.group(Map)
     poller: Poller = environ.group(Poller)
     web: Web = environ.group(Web)
 

--- a/meshinfo/templates/map.jinja2
+++ b/meshinfo/templates/map.jinja2
@@ -14,7 +14,10 @@
 <script src="{{ req.static_url("meshinfo:static/leaflet/leaflet.js") }}"></script>
 <script src="{{ req.static_url("meshinfo:static/js/leaflet.polylineoffset.js") }}"></script>
 <script type="text/javascript">
-  let map = L.map('map').setView([42.35, -122.83], 13);
+  let map = L.map('map', {
+    center: [{{ latitude }}, {{ longitude }}],
+    zoom: {{ zoom }}
+  });
   L.tileLayer('//stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg', {
     attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
     maxZoom: 18,

--- a/meshinfo/views/map.py
+++ b/meshinfo/views/map.py
@@ -10,6 +10,7 @@ from pyramid.request import Request
 from pyramid.view import view_config
 from sqlalchemy.orm import Session, aliased
 
+from ..config import AppConfig
 from ..models import Link, Node
 from ..types import LinkStatus, LinkType, NodeStatus
 
@@ -41,12 +42,19 @@ def network_map(request: Request):
     # TODO: read starting coordinates/zoom from query string
     # (and/or use https://github.com/mlevans/leaflet-hash)
 
+    config: AppConfig = request.registry.settings["app_config"]
+
     node_icons = {
         key: request.static_url(f"meshinfo:static/img/map/{filename}")
         for key, filename in NODE_ICONS
     }
 
-    return {"node_icons": node_icons}
+    return {
+        "node_icons": node_icons,
+        "latitude": config.map.latitude,
+        "longitude": config.map.longitude,
+        "zoom": config.map.zoom,
+    }
 
 
 @view_config(route_name="map-data", renderer="json")


### PR DESCRIPTION
Change the default map to show most of the world.
Add configuration options for the latitude, longitude, and zoom.
Document most of the configuration options.

Fixes #45