### PR TITLE
Fix icon color for 3 GHz

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Fixed
 
 * Added new 2GHz channels (`#40 <https://github.com/smsearcy/mesh-info/issues/40>`_)
 * Added new 5GHz channel (`#44 <https://github.com/smsearcy/mesh-info/issues/44>`_)
+* Fix 3GHz icon color (`#49 <https://github.com/smsearcy/mesh-info/issues/49>`_)
 
 
 0.4.0 - 2022-06-02

--- a/meshinfo/views/map.py
+++ b/meshinfo/views/map.py
@@ -17,7 +17,7 @@ from ..types import LinkStatus, LinkType, NodeStatus
 NODE_ICONS = [
     ("900MHz", "magentaRadioCircle-icon.png"),
     ("2GHz", "purpleRadioCircle-icon.png"),
-    ("3GHz", "blueRadioCircle-icon.png"),
+    ("3GHZ", "blueRadioCircle-icon.png"),
     ("5GHz", "goldRadioCircle-icon.png"),
     ("Unknown", "greyRadioCircle-icon.png"),
 ]


### PR DESCRIPTION
Fix typo that prevented 3 GHz radios from using the correct icon (blue).

Fixes #49