### PR TITLE
Update dependencies

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,8 +1,8 @@
 -c requirements.txt
-Faker>=8.0.0
+Faker>=13.15.0
 WebTest>=2.0.35
 flake8-bugbear>=21.3.1
-flake8>=3.7.9
+flake8>=4.0.1
 flake8_formatter_junit_xml>=0.0.6
 mypy
 pip-tools
@@ -12,6 +12,7 @@ pytest-cov>=2.8.1
 pytest-mock>=3.3.1
 pytest-postgresql<4.0.0
 pytest>=6.2.0
-sphinx>=4.5.0,<5.0
+# using Sphinx >= 4.4.0 causes dependency collisions in Python 3.7
+sphinx==4.3.2
 sphinx-rtd-theme
 types-waitress>=0.1.4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -29,14 +29,14 @@ docutils==0.17.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
-faker==13.3.4
+faker==13.15.0
     # via -r dev-requirements.in
 flake8==4.0.1
     # via
     #   -r dev-requirements.in
     #   flake8-bugbear
     #   flake8-formatter-junit-xml
-flake8-bugbear==22.3.23
+flake8-bugbear==22.7.1
     # via -r dev-requirements.in
 flake8-formatter-junit-xml==0.0.6
     # via -r dev-requirements.in
@@ -50,17 +50,15 @@ idna==3.3
     #   requests
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.11.3
-    # via sphinx
 iniconfig==1.1.1
     # via pytest
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   -c requirements.txt
     #   sphinx
 junit-xml==1.9
     # via flake8-formatter-junit-xml
-mako==1.2.0
+mako==1.2.1
     # via
     #   -c requirements.txt
     #   pyramid-mako
@@ -73,7 +71,7 @@ mccabe==0.6.1
     # via flake8
 mirakuru==2.4.2
     # via pytest-postgresql
-mypy==0.942
+mypy==0.961
     # via -r dev-requirements.in
 mypy-extensions==0.4.3
     # via mypy
@@ -125,7 +123,7 @@ pyramid-debugtoolbar==4.9
     # via -r dev-requirements.in
 pyramid-mako==1.1.0
     # via pyramid-debugtoolbar
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   -r dev-requirements.in
     #   pytest-asyncio
@@ -136,7 +134,7 @@ pytest-asyncio==0.18.3
     # via -r dev-requirements.in
 pytest-cov==3.0.0
     # via -r dev-requirements.in
-pytest-mock==3.7.0
+pytest-mock==3.8.2
     # via -r dev-requirements.in
 pytest-postgresql==3.1.3
     # via -r dev-requirements.in
@@ -159,7 +157,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.3.1
     # via beautifulsoup4
-sphinx==4.5.0
+sphinx==4.3.2
     # via
     #   -r dev-requirements.in
     #   sphinx-rtd-theme
@@ -208,8 +206,6 @@ webtest==3.0.0
     # via -r dev-requirements.in
 wheel==0.37.1
     # via pip-tools
-zipp==3.8.0
-    # via importlib-metadata
 zope-deprecation==4.4.0
     # via
     #   -c requirements.txt

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -215,6 +215,7 @@ To get the latest version of Mesh Info, run the following:
     $ sudo systemctl stop meshinfo-web meshinfo-collector
     $ cd /opt/mesh-info/src
     $ sudo -u meshinfo git pull
+    $ sudo -u meshinfo pip install -r requirements.txt
     $ sudo -u meshinfo /opt/mesh-info/bin/alembic -c /opt/mesh-info/src/alembic.ini upgrade head
     $ sudo systemctl restart meshinfo-web meshinfo-collector
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
-aiohttp>=3.7.4,<4
+aiohttp>=3.8.1,<4
 alembic>=1.8.0
-attrs>=21.2.0,<22.0
-environ-config>=21.2.0
+attrs>=21.4.0
+environ-config>=22.1.0
 gunicorn>=20.1.0
 loguru>=0.5.0,<1.0
 pendulum>=2.1.2,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.8.1
     # via -r requirements.in
 aiosignal==1.2.0
     # via aiohttp
-alembic==1.7.7
+alembic==1.8.0
     # via -r requirements.in
 async-timeout==4.0.2
     # via aiohttp
@@ -19,7 +19,7 @@ attrs==21.4.0
     #   environ-config
 charset-normalizer==2.0.12
     # via aiohttp
-environ-config==21.2.0
+environ-config==22.1.0
     # via -r requirements.in
 frozenlist==1.3.0
     # via
@@ -33,11 +33,11 @@ hupper==1.10.3
     # via pyramid
 idna==3.3
     # via yarl
-jinja2==3.1.1
+jinja2==3.1.2
     # via pyramid-jinja2
 loguru==0.6.0
     # via -r requirements.in
-mako==1.2.0
+mako==1.2.1
     # via alembic
 markupsafe==2.1.1
     # via
@@ -87,7 +87,7 @@ rrdtool==0.1.15
     # via -r requirements.in
 six==1.16.0
     # via python-dateutil
-sqlalchemy==1.4.32
+sqlalchemy==1.4.39
     # via
     #   -r requirements.in
     #   alembic


### PR DESCRIPTION
Mostly updates, but rollback Sphinx to deal with failing Python 3.7 test.
Add note to documents about updating dependencies when installing.

Fixes #37