### PR TITLE
Fix upgrade instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -215,8 +215,8 @@ To get the latest version of Mesh Info, run the following:
     $ sudo systemctl stop meshinfo-web meshinfo-collector
     $ cd /opt/mesh-info/src
     $ sudo -u meshinfo git pull
-    $ sudo -u meshinfo pip install -r requirements.txt
-    $ sudo -u meshinfo /opt/mesh-info/bin/alembic -c /opt/mesh-info/src/alembic.ini upgrade head
+    $ sudo -u meshinfo /opt/mesh-info/bin/pip install -r requirements.txt
+    $ sudo -u meshinfo /opt/mesh-info/bin/alembic upgrade head
     $ sudo systemctl restart meshinfo-web meshinfo-collector
 
 .. warning::


### PR DESCRIPTION
The `pip` command to install/upgrade packages did not run in the virtualenv.

Alembic configuration file path is not necessary if current directory is `/opt/mesh-info/src`.