### PR TITLE
Fix some parsing issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Fixed
 * Added new 2GHz channels (`#40 <https://github.com/smsearcy/mesh-info/issues/40>`_)
 * Added new 5GHz channel (`#44 <https://github.com/smsearcy/mesh-info/issues/44>`_)
 * Fix 3GHz icon color (`#49 <https://github.com/smsearcy/mesh-info/issues/49>`_)
+* Fix link destination name issue (`#52 <https://github.com/smsearcy/mesh-info/issues/52>`_)
 
 
 0.4.0 - 2022-06-02

--- a/meshinfo/aredn.py
+++ b/meshinfo/aredn.py
@@ -242,9 +242,12 @@ class LinkInfo:
             logger.warning(str(exc))
             link_type = LinkType.UNKNOWN
 
+        # ensure consistent node names
+        node_name = raw_data["hostname"].replace(".local.mesh", "").lstrip(".").lower()
+
         return LinkInfo(
             source=source,
-            destination=raw_data["hostname"].lower().replace(".local.mesh", ""),
+            destination=node_name,
             destination_ip=ip_address,
             type=link_type,
             interface=raw_data["olsrInterface"],
@@ -475,12 +478,14 @@ def load_system_info(json_data: Dict[str, Any]) -> SystemInfo:
     else:
         data["active_tunnel_count"] = int(json_data["active_tunnel_count"])
 
-    data["links"] = [
-        LinkInfo.from_json(
-            link_info, source=data["node_name"].lower(), ip_address=ip_address
-        )
-        for ip_address, link_info in json_data.get("link_info", {}).items()
-    ]
+    # py3.8: use walrus operator
+    if json_data.get("link_info"):
+        data["links"] = [
+            LinkInfo.from_json(
+                link_info, source=data["node_name"].lower(), ip_address=ip_address
+            )
+            for ip_address, link_info in json_data["link_info"].items()
+        ]
 
     return SystemInfo(**data)
 

--- a/tests/data/sysinfo-1.11-no-links.json
+++ b/tests/data/sysinfo-1.11-no-links.json
@@ -1,0 +1,106 @@
+{
+  "lon": "4.807427",
+  "sysinfo": {
+    "uptime": "22 days, 13:17:23",
+    "loads": [
+      0.72,
+      0.64,
+      0.63
+    ]
+  },
+  "interfaces": [
+    {
+      "mac": "49:26:0F:BD:EA:31",
+      "name": "br-lan",
+      "ip": "10.126.149.161"
+    },
+    {
+      "name": "tun62",
+      "ip": "172.31.92.97"
+    },
+    {
+      "name": "tun50",
+      "ip": "172.31.174.74"
+    },
+    {
+      "mac": "49:26:0F:BD:EA:31",
+      "name": "eth1.2",
+      "ip": "10.16.210.180"
+    },
+    {
+      "name": "tunl0",
+      "mac": "00:00:00:00"
+    },
+    {
+      "mac": "CC:27:C9:7A:33:0D",
+      "name": "eth0",
+      "ip": "10.0.2.5"
+    },
+    {
+      "name": "tun61",
+      "ip": "172.31.166.65"
+    },
+    {
+      "name": "wlan0",
+      "mac": "D5:BB:E5:74:CF:25"
+    },
+    {
+      "name": "tun53",
+      "ip": "172.31.174.86"
+    },
+    {
+      "name": "tun52",
+      "ip": "172.31.174.82"
+    },
+    {
+      "name": "tun60",
+      "ip": "172.31.245.121"
+    },
+    {
+      "name": "tun51",
+      "ip": "172.31.174.78"
+    },
+    {
+      "name": "eth1.0",
+      "mac": "49:26:0F:BD:EA:31"
+    },
+    {
+      "mac": "98:8B:18:6E:E0:D4",
+      "name": "wlan1",
+      "ip": "10.15.210.180"
+    },
+    {
+      "name": "eth1",
+      "mac": "49:26:0F:BD:EA:31"
+    }
+  ],
+  "api_version": "1.11",
+  "lat": "-61.127232",
+  "meshrf": {
+    "ssid": "ArednMeshNetwork",
+    "channel": "-2",
+    "status": "on",
+    "freq": "2397",
+    "chanbw": "10"
+  },
+  "services_local": [
+    {
+      "name": "MeshChat",
+      "protocol": "tcp",
+      "link": "http://N0CALL-hAP:8080/meshchat"
+    }
+  ],
+  "tunnels": {
+    "active_tunnel_count": "7"
+  },
+  "link_info": [],
+  "grid_square": "EB76co",
+  "node": "N0CALL-hAP",
+  "node_details": {
+    "model": "MikroTik RouterBOARD RB952Ui-5ac2nD",
+    "mesh_gateway": "0",
+    "firmware_mfg": "AREDN",
+    "board_id": "0x0000",
+    "firmware_version": "3.22.6.0"
+  }
+}

--- a/tests/data/sysinfo-1.7-invalid-link-name.json
+++ b/tests/data/sysinfo-1.7-invalid-link-name.json
@@ -1,0 +1,198 @@
+{
+  "lon": "59.121308",
+  "sysinfo": {
+    "uptime": "45 days, 1:16:22",
+    "loads": [
+      1.19,
+      1.24,
+      1.17
+    ]
+  },
+  "interfaces": [
+    {
+      "mac": "7B:B1:72:E7:50:8B",
+      "name": "br-lan",
+      "ip": "10.250.72.1"
+    },
+    {
+      "name": "tun62",
+      "ip": "172.31.174.49"
+    },
+    {
+      "mac": "7B:B1:72:E7:50:8B",
+      "name": "eth1.2",
+      "ip": "10.88.210.64"
+    },
+    {
+      "name": "tunl0",
+      "mac": "00:00:00:00"
+    },
+    {
+      "mac": "B5:F6:0B:6D:26:B5",
+      "name": "eth0",
+      "ip": "192.168.55.3"
+    },
+    {
+      "name": "tun61",
+      "ip": "172.31.95.129"
+    },
+    {
+      "name": "wlan0",
+      "mac": "8C:C9:6D:1C:AB:E3"
+    },
+    {
+      "name": "tun60",
+      "ip": "172.31.8.229"
+    },
+    {
+      "mac": "7B:B1:72:E7:50:8B",
+      "name": "eth1.3975",
+      "ip": "10.87.210.64"
+    },
+    {
+      "name": "tun53",
+      "ip": "172.31.58.86"
+    },
+    {
+      "name": "tun54",
+      "ip": "172.31.58.90"
+    },
+    {
+      "name": "tun58",
+      "ip": "172.31.58.106"
+    },
+    {
+      "name": "eth1.0",
+      "mac": "7B:B1:72:E7:50:8B"
+    },
+    {
+      "name": "tun52",
+      "ip": "172.31.58.82"
+    },
+    {
+      "name": "wlan1",
+      "mac": "48:87:9A:A5:A8:3C"
+    },
+    {
+      "name": "eth1",
+      "mac": "7B:B1:72:E7:50:8B"
+    }
+  ],
+  "api_version": "1.7",
+  "link_info": {
+    "172.31.58.81": {
+      "neighborLinkQuality": 1,
+      "linkQuality": 1,
+      "hostname": "N0CALL-QTW-RF",
+      "olsrInterface": "tun52",
+      "linkType": "TUN"
+    },
+    "172.31.95.130": {
+      "neighborLinkQuality": 1,
+      "linkQuality": 1,
+      "hostname": ".N0CALL-TUN-SLM",
+      "olsrInterface": "tun61",
+      "linkType": "TUN"
+    },
+    "172.31.58.105": {
+      "neighborLinkQuality": 1,
+      "linkQuality": 1,
+      "hostname": "N0CALL-QTH-TUN",
+      "olsrInterface": "tun58",
+      "linkType": "TUN"
+    },
+    "172.31.58.85": {
+      "neighborLinkQuality": 1,
+      "linkQuality": 1,
+      "hostname": "N0CALL-GLENADA-RTR",
+      "olsrInterface": "tun53",
+      "linkType": "TUN"
+    },
+    "172.31.8.230": {
+      "neighborLinkQuality": 1,
+      "linkQuality": 1,
+      "hostname": "N0CALL-QTH",
+      "olsrInterface": "tun60",
+      "linkType": "TUN"
+    },
+    "172.31.58.89": {
+      "neighborLinkQuality": 1,
+      "linkQuality": 1,
+      "hostname": "N0CALL-hAP01",
+      "olsrInterface": "tun54",
+      "linkType": "TUN"
+    },
+    "172.31.174.50": {
+      "neighborLinkQuality": 1,
+      "linkQuality": 1,
+      "hostname": "N0CALL-QTH-hAP",
+      "olsrInterface": "tun62",
+      "linkType": "TUN"
+    }
+  },
+  "meshrf": {
+    "status": "off"
+  },
+  "tunnels": {
+    "active_tunnel_count": "7",
+    "tunnel_installed": "true"
+  },
+  "services_local": [
+    {
+      "name": "RMS",
+      "protocol": "tcp",
+      "link": "http://N0CALL-RMS:0/"
+    },
+    {
+      "name": "APRS-IS Status",
+      "protocol": "tcp",
+      "link": "http://N0CALL-APRS-IS:14501/"
+    },
+    {
+      "name": "PBX INFO",
+      "protocol": "tcp",
+      "link": "http://N0CALL-PBX:80/"
+    },
+    {
+      "name": "DMR-Server INFO",
+      "protocol": "tcp",
+      "link": "http://N0CALL-DMR-SERVER:80/"
+    },
+    {
+      "name": "File Server",
+      "protocol": "tcp",
+      "link": "http://N0CALL-Server:80/file-manager/"
+    },
+    {
+      "name": "MeshMap",
+      "protocol": "tcp",
+      "link": "http://N0CALL-Server:80/meshmap/"
+    },
+    {
+      "name": "WVMN-Wiki",
+      "protocol": "tcp",
+      "link": "http://N0CALL-Server:80/wiki/"
+    },
+    {
+      "name": "APRS Map",
+      "protocol": "tcp",
+      "link": "http://N0CALL-Server:80/aprsmap/"
+    },
+    {
+      "name": "SpotRep Map",
+      "protocol": "tcp",
+      "link": "http://N0CALL-Server:80/spotrep/"
+    }
+  ],
+  "lat": "-38.922138",
+  "nodes": "262",
+  "grid_square": "MI36fv",
+  "node": "N0CALL-QTW-TUN",
+  "node_details": {
+    "description": "K9RCP Work Tunnel Device",
+    "model": "MikroTik RouterBOARD RB952Ui-5ac2nD",
+    "board_id": "0x0000",
+    "firmware_mfg": "AREDN",
+    "firmware_version": "0.00.0"
+  }
+}

--- a/tests/test_aredn.py
+++ b/tests/test_aredn.py
@@ -311,6 +311,24 @@ def test_dtd_link_info_no_type(data_folder):
     assert sample_link == expected
 
 
+def test_link_name_with_leading_period(data_folder):
+    """Confirm that fix for extra period in names is working."""
+    with open(data_folder / "sysinfo-1.7-invalid-link-name.json", "r") as f:
+        json_data = json.load(f)
+    system_info = aredn.load_system_info(json_data)
+
+    assert system_info.links[1].destination == "n0call-tun-slm"
+
+
+def test_empty_link_info(data_folder):
+    """Empty `link_info` data returns empty list instead of empty dictionary."""
+    with open(data_folder / "sysinfo-1.11-no-links.json", "r") as f:
+        json_data = json.load(f)
+    system_info = aredn.load_system_info(json_data)
+
+    assert system_info.links == []
+
+
 def test_invalid_link_json():
     """Confirm that an unknown link is gracefully handled."""
     link_json = {


### PR DESCRIPTION
Gracefully handle empty "link_info" JSON object (it returned an empty list instead of a dictionary when there was no data).  It appeared to be an intermittent issue but this way we don't have a parse issue.

Strip leading period in the link destination host name that caused issues building the links.

Add tests for both issues.

Fixes #52