### PR TITLE
Sort firmware versions as numbers, not strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Fixed
 * Added new 5GHz channel (`#44 <https://github.com/smsearcy/mesh-info/issues/44>`_)
 * Fix 3GHz icon color (`#49 <https://github.com/smsearcy/mesh-info/issues/49>`_)
 * Fix link destination name issue (`#52 <https://github.com/smsearcy/mesh-info/issues/52>`_)
+* Node list firmware sorted "naturally" (`#48 <https://github.com/smsearcy/mesh-info/issues/48>`_)
 
 
 0.4.0 - 2022-06-02

--- a/meshinfo/templates/nodes.jinja2
+++ b/meshinfo/templates/nodes.jinja2
@@ -36,7 +36,28 @@
         'Band',
         'Links',
         'Tunnels',
-        'Firmware',
+        {
+          name: 'Firmware',
+          sort: {
+            compare: (a, b) => {
+              const a_parts = a.replace('develop-', '').split(/[-.]/);
+              const b_parts = b.replace('develop-', '').split(/[-.]/);
+
+              let i = 0;
+              while (i < Math.min(a_parts.length, b_parts.length)) {
+                let a_part = parseInt(a_parts[i], 10);
+                let b_part = parseInt(b_parts[i], 10);
+                if (a_part > b_part) {
+                  return 1;
+                } else if (b_part > a_part) {
+                  return -1;
+                }
+                i++;
+              }
+              return 0;
+            }
+          }
+        },
         {
           name: 'Up Time',
           sort: false


### PR DESCRIPTION
Fix the firmware sort on the Node List page to be more natural.

Fixes #48