### PR TITLE
Use enum for RF bands

### DIFF
--- a/alembic/versions/c0541aabafa8_band_enum.py
+++ b/alembic/versions/c0541aabafa8_band_enum.py
@@ -1,0 +1,23 @@
+"""Fix for RF band typo (and now using enum).
+
+Revision ID: c0541aabafa8
+Revises: 0ab33c522eef
+Create Date: 2022-07-26 16:25:53.305063
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c0541aabafa8"
+down_revision = "0ab33c522eef"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Fix typo in the 3 GHz band
+    op.execute("UPDATE node SET band = '3GHz' WHERE band = '3GHZ'")
+
+
+def downgrade():
+    pass

--- a/alembic/versions/f7672ee42a36_initial.py
+++ b/alembic/versions/f7672ee42a36_initial.py
@@ -67,7 +67,20 @@ def upgrade():
         sa.Column("ssid", sa.String(length=50), nullable=False),
         sa.Column("channel", sa.String(length=50), nullable=False),
         sa.Column("channel_bandwidth", sa.String(length=50), nullable=False),
-        sa.Column("band", sa.String(length=25), nullable=False),
+        sa.Column(
+            "band",
+            sa.Enum(
+                "900MHz",
+                "2GHz",
+                "3GHz",
+                "5GHz",
+                "Unknown",
+                "",
+                name="band",
+                native_enum=False,
+            ),
+            nullable=False,
+        ),
         sa.Column("services", sa.JSON(), nullable=False),
         sa.Column("tunnel_installed", sa.Boolean(), nullable=False),
         sa.Column("active_tunnel_count", sa.Integer(), nullable=False),
@@ -93,7 +106,7 @@ def upgrade():
         sa.Column("destination_id", sa.Integer(), nullable=False),
         sa.Column(
             "type",
-            sa.Enum("DTD", "TUN", "RF", "UNKNOWN", name="linktype"),
+            sa.Enum("DTD", "TUN", "RF", "UNKNOWN", name="linktype", native_enum=False),
             nullable=False,
         ),
         sa.Column(

--- a/meshinfo/aredn.py
+++ b/meshinfo/aredn.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import attr
 from loguru import logger
 
-from .types import LinkType
+from .types import Band, LinkType
 
 if typing.TYPE_CHECKING:
     from .config import AppConfig
@@ -338,19 +338,19 @@ class SystemInfo:
         return getattr(self.wlan_interface, "mac_address", "").replace(":", "").lower()
 
     @property
-    def band(self) -> str:
+    def band(self) -> Band:
         if self.status != "on":
-            return ""
+            return Band.OFF
         if self.board_id in NINE_HUNDRED_MHZ_BOARDS:
-            return "900MHz"
+            return Band.NINE_HUNDRED_MHZ
         elif self.channel in TWO_GHZ_CHANNELS:
-            return "2GHz"
+            return Band.TWO_GHZ
         elif self.channel in THREE_GHZ_CHANNELS:
-            return "3GHZ"
+            return Band.THREE_GHZ
         elif self.channel in FIVE_GHZ_CHANNELS:
-            return "5GHz"
+            return Band.FIVE_GHZ
         else:
-            return "Unknown"
+            return Band.UNKNOWN
 
     @property
     def up_time_seconds(self) -> Optional[int]:

--- a/meshinfo/models/link.py
+++ b/meshinfo/models/link.py
@@ -15,7 +15,7 @@ class Link(Base):
     destination_id = sa.Column(
         sa.Integer, sa.ForeignKey("node.node_id"), primary_key=True
     )
-    type = sa.Column(sa.Enum(LinkType), primary_key=True)
+    type = sa.Column(sa.Enum(LinkType, native_enum=False), primary_key=True)
     status = sa.Column(sa.Enum(LinkStatus, native_enum=False), nullable=False)
     last_seen = sa.Column(PDateTime(), nullable=False, default=pendulum.now)
 

--- a/meshinfo/models/node.py
+++ b/meshinfo/models/node.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 
-from ..types import NodeStatus
+from ..types import Band, NodeStatus
 from .meta import Base, PDateTime
 
 
@@ -51,7 +51,10 @@ class Node(Base):
     ssid = Column(String(50), nullable=False)
     channel = Column(String(50), nullable=False)
     channel_bandwidth = Column(String(50), nullable=False)
-    band = Column(String(25), nullable=False)
+    band = Column(
+        Enum(Band, values_callable=lambda x: [e.value for e in x], native_enum=False),
+        nullable=False,
+    )
 
     services = Column(JSON(), nullable=False)
 

--- a/meshinfo/report.py
+++ b/meshinfo/report.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 from .aredn import LinkInfo, SystemInfo, VersionChecker
 from .poller import NetworkInfo, NodeResult, OlsrData, Poller, PollingError
-from .types import LinkType
+from .types import Band, LinkType
 
 VERBOSE_TO_LOGGING = {0: "SUCCESS", 1: "INFO", 2: "DEBUG", 3: "TRACE"}
 
@@ -137,7 +137,7 @@ def pprint_node(node: SystemInfo, checker: VersionChecker):
         mesh_info = f"{OK}on{END}\tSSID: {INFO}{node.ssid}{END}"
     print("MESH RF:", mesh_info)
 
-    band_color = WARN if node.band == "Unknown" else INFO
+    band_color = WARN if node.band == Band.UNKNOWN else INFO
     print(f"Channel: {node.channel}\tBand: {band_color}{node.band}{END}")
     api_color = VERSION_COLOR.get(checker.api(node.api_version), WARN)
     print(f"API Version: {api_color}{node.api_version}{END}")

--- a/meshinfo/templates/map.jinja2
+++ b/meshinfo/templates/map.jinja2
@@ -25,7 +25,7 @@
 
   let node_icons = {
   {% for band, icon_url in node_icons.items() -%}
-    '{{ band }}': L.icon({iconUrl: '{{ icon_url }}', iconSize: [18, 18], iconAnchor: [9, 9], popupAnchor: [0, -9]}),
+    '{{ band.value }}': L.icon({iconUrl: '{{ icon_url }}', iconSize: [18, 18], iconAnchor: [9, 9], popupAnchor: [0, -9]}),
   {% endfor -%}
   }
 

--- a/meshinfo/types.py
+++ b/meshinfo/types.py
@@ -82,3 +82,26 @@ class NodeStatus(enum.Enum):
 
     def __str__(self):
         return self.name.title()
+
+
+class Band(enum.Enum):
+    """Enumerate possible AREDN mesh bands."""
+
+    # These values need to stay consistent because they are used in the database
+    NINE_HUNDRED_MHZ = "900MHz"
+    TWO_GHZ = "2GHz"
+    THREE_GHZ = "3GHz"
+    FIVE_GHZ = "5GHz"
+    UNKNOWN = "Unknown"
+    OFF = ""
+
+    def __str__(self):
+        labels = {
+            Band.NINE_HUNDRED_MHZ: "900 MHz",
+            Band.TWO_GHZ: "2 GHz",
+            Band.THREE_GHZ: "3 GHz",
+            Band.FIVE_GHZ: "5 GHz",
+            Band.UNKNOWN: "Unknown",
+            Band.OFF: "RF Off",
+        }
+        return labels.get(self, "Unknown")

--- a/meshinfo/views/map.py
+++ b/meshinfo/views/map.py
@@ -12,15 +12,15 @@ from sqlalchemy.orm import Session, aliased
 
 from ..config import AppConfig
 from ..models import Link, Node
-from ..types import LinkStatus, LinkType, NodeStatus
+from ..types import Band, LinkStatus, LinkType, NodeStatus
 
 # TODO: make an enum for bands
 NODE_ICONS = [
-    ("900MHz", "magentaRadioCircle-icon.png"),
-    ("2GHz", "purpleRadioCircle-icon.png"),
-    ("3GHZ", "blueRadioCircle-icon.png"),
-    ("5GHz", "goldRadioCircle-icon.png"),
-    ("Unknown", "greyRadioCircle-icon.png"),
+    (Band.NINE_HUNDRED_MHZ, "magentaRadioCircle-icon.png"),
+    (Band.TWO_GHZ, "purpleRadioCircle-icon.png"),
+    (Band.THREE_GHZ, "blueRadioCircle-icon.png"),
+    (Band.FIVE_GHZ, "goldRadioCircle-icon.png"),
+    (Band.OFF, "greyRadioCircle-icon.png"),
 ]
 
 
@@ -104,7 +104,7 @@ def _node_geo_json(node: Node, request: Request) -> dict:
         "properties": {
             "id": str(node.id),
             "name": node.name,
-            "band": node.band,
+            "band": node.band.value,
             "previewUrl": request.route_url("node-preview", id=node.id),
         },
     }

--- a/tests/test_aredn.py
+++ b/tests/test_aredn.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from meshinfo import aredn
-from meshinfo.types import LinkType
+from meshinfo.types import Band, LinkType
 
 
 @pytest.mark.parametrize(
@@ -99,7 +99,7 @@ def test_api_version_1_6(data_folder):
     assert system_info.active_tunnel_count == 0
     assert len(system_info.services) == 1
     assert system_info.wlan_ip_address == "10.159.123.176"
-    assert system_info.band == "2GHz"
+    assert system_info.band == Band.TWO_GHZ
 
 
 def test_api_version_1_7(data_folder):
@@ -127,7 +127,7 @@ def test_api_version_1_7(data_folder):
     assert system_info.up_time_seconds == 330_245
     assert system_info.active_tunnel_count == 0
     assert system_info.wlan_ip_address == "10.106.204.11"
-    assert system_info.band == "5GHz"
+    assert system_info.band == Band.FIVE_GHZ
 
 
 def test_api_version_1_9(data_folder):
@@ -155,7 +155,7 @@ def test_api_version_1_9(data_folder):
     assert system_info.up_time_seconds == 658282
     assert system_info.active_tunnel_count == 0
     assert system_info.wlan_ip_address == "10.10.115.143"
-    assert system_info.band == "2GHz"
+    assert system_info.band == Band.TWO_GHZ
     assert len(system_info.links) == 1
 
     sample_link = system_info.links[0]


### PR DESCRIPTION
Use a Python enum instead of a string for the RF bands.
Update labels displayed on website.

- [x] Test the collector with the new band enums before merging

Fixes #46