### PR TITLE
Update how firmware statistics are reported

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Changed
 ^^^^^^^
 
 * Bumped current AREDN version (`#38 <https://github.com/smsearcy/mesh-info/issues/38>`_)
+* Group nightly firmware versions and add API version statistics (`#42 <https://github.com/smsearcy/mesh-info/issues/42>`_)
 
 Fixed
 ^^^^^

--- a/meshinfo/templates/home.jinja2
+++ b/meshinfo/templates/home.jinja2
@@ -117,6 +117,27 @@
         </div>
       </div>
     </div>
+    <div class="column is-narrow">
+      <div class="card">
+        <header class="card-header">
+          <p class="card-header-title">API Versions</p>
+        </header>
+        <div class="card-content">
+          <div class="content">
+            <table class="table">
+              <tbody>
+              {% for version, count in api_stats|dictsort(by='value', reverse=True) %}
+                <tr>
+                  <th>{{ version }}:</th>
+                  <td>{{ "{:,d}".format(count) }}</td>
+                </tr>
+              {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <h2 class="title is-3">Recent Node Errors</h2>
 {% if last_run %}


### PR DESCRIPTION
Group any non-AREDN firmware.
Group all development versions under "Nightly".
Add "API Versions" to count nodes by API versions.

Closes #42