### PR TITLE
Cap link cost from API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Changed
 
 * Bumped current AREDN version (`#38 <https://github.com/smsearcy/mesh-info/issues/38>`_)
 * Group nightly firmware versions and add API version statistics (`#42 <https://github.com/smsearcy/mesh-info/issues/42>`_)
+* Cap link cost from API at 99.99 for consistency (`#81 <https://github.com/smsearcy/mesh-info/issues/81>`_)
 
 Fixed
 ^^^^^

--- a/meshinfo/aredn.py
+++ b/meshinfo/aredn.py
@@ -244,6 +244,10 @@ class LinkInfo:
 
         # ensure consistent node names
         node_name = raw_data["hostname"].replace(".local.mesh", "").lstrip(".").lower()
+        # py3.8 use walrus?
+        link_cost = raw_data.get("linkCost")
+        if link_cost is not None and link_cost > 99.99:
+            link_cost = 99.99
 
         return LinkInfo(
             source=source,
@@ -257,7 +261,7 @@ class LinkInfo:
             noise=raw_data.get("noise"),
             tx_rate=raw_data.get("tx_rate"),
             rx_rate=raw_data.get("rx_rate"),
-            olsr_cost=raw_data.get("linkCost"),
+            olsr_cost=link_cost,
         )
 
 

--- a/tests/test_aredn.py
+++ b/tests/test_aredn.py
@@ -353,6 +353,56 @@ def test_invalid_link_json():
     assert link_info == expected
 
 
+def test_link_cost_cap():
+    """Confirm that high link cost is being capped to match OLSR."""
+    link_json = {
+        "helloTime": 0,
+        "lostLinkTime": 0,
+        "linkQuality": 0.094,
+        "vtime": 20000,
+        "linkCost": 4194304,
+        "linkType": "RF",
+        "hostname": "N0CALL-NSM2-3-RVAA",
+        "previousLinkStatus": "SYMMETRIC",
+        "currentLinkStatus": "SYMMETRIC",
+        "rx_rate": 1.4,
+        "neighborLinkQuality": 0.784,
+        "noise": -86,
+        "symmetryTime": 18193,
+        "seqnoValid": False,
+        "lossMultiplier": 65536,
+        "pending": False,
+        "lossHelloInterval": 2000,
+        "asymmetryTime": 388749418,
+        "tx_rate": 3.2,
+        "hysteresis": 0,
+        "seqno": 0,
+        "lossTime": 1193,
+        "validityTime": 36989,
+        "olsrInterface": "wlan0",
+        "lastHelloTime": 0,
+        "signal": -83,
+    }
+    link_info = aredn.LinkInfo.from_json(
+        link_json, source="N0CALL-hAP-AC-4", ip_address="10.84.160.54"
+    )
+    expected = aredn.LinkInfo(
+        source="N0CALL-hAP-AC-4",
+        destination="n0call-nsm2-3-rvaa",
+        destination_ip="10.84.160.54",
+        quality=0.094,
+        neighbor_quality=0.784,
+        olsr_cost=99.99,
+        signal=-83,
+        noise=-86,
+        tx_rate=3.2,
+        rx_rate=1.4,
+        type=LinkType.RF,
+        interface="wlan0",
+    )
+    assert link_info == expected
+
+
 def test_version_checker():
     checker = aredn.VersionChecker((3, 20, 2, 0), (1, 7))
     assert checker.firmware("3.20.2.0") == 0


### PR DESCRIPTION
The link cost in OLSR maxes at 99.99, but the API `linkCost` goes up into the thousands, which is meaningless and makes the graphs less usable.  So cap everything at 99.99.