### PR TITLE
Add cache busting for static assets

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -180,6 +180,7 @@ Create ``/etc/nginx/sites-available/mesh-info`` with the following content
         gzip_types application/json;
         gzip_proxied any;
 
+        # reverse proxy the Gunicorn app server
         location / {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -189,8 +190,11 @@ Create ``/etc/nginx/sites-available/mesh-info`` with the following content
             # redirects, we set the Host: header above already.
             proxy_redirect off;
             proxy_pass http://app_server;
+        }
 
-            # TODO: have NGINX cache static content once cache busting is configured
+        # server static files via NGINX
+        location /static {
+            root /opt/mesh-info/src/meshinfo;
         }
     }
 

--- a/meshinfo/config.py
+++ b/meshinfo/config.py
@@ -154,19 +154,12 @@ def configure(
     filters.setdefault("local_tz", "meshinfo.filters.local_tz")
 
     if app_config.env == Environment.DEV:
-        settings["pyramid.reload_all"] = True
-        settings["pyramid.debug_authorization"] = False
-        settings["pyramid.debug_notfound"] = False
-        settings["pyramid.debug_routematch"] = False
-        settings["pyramid.default_locale_name"] = "en"
         settings["debugtoolbar.max_visible_requests"] = 25
-
-    else:
-        settings["pyramid.reload_templates"] = False
         settings["pyramid.debug_authorization"] = False
         settings["pyramid.debug_notfound"] = False
         settings["pyramid.debug_routematch"] = False
-        settings["pyramid.default_locale_name"] = "en"
+        settings["pyramid.prevent_cachebust"] = True
+        settings["pyramid.reload_all"] = True
 
     # configure logging
     logger.remove()


### PR DESCRIPTION
Use query string parameter to bust the cache, ensuring static assets are updated when the application is updated.
Document configuring NGINX serving static assets (it really wasn't dependent on cache busting, but now is a good time to add it).