### PR TITLE
Ensure positive bearings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Changed
 Fixed
 ^^^^^
 
+* Bearings are always positive numbers (0 - 359).
 
 0.5.1 - 2022-10-07
 ------------------

--- a/alembic/versions/43142bd50852_normalize_bearing.py
+++ b/alembic/versions/43142bd50852_normalize_bearing.py
@@ -1,0 +1,22 @@
+"""Normalize the bearing so always positive.
+
+Revision ID: 43142bd50852
+Revises: c0541aabafa8
+Create Date: 2023-01-06 18:48:55.197296
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "43142bd50852"
+down_revision = "c0541aabafa8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("UPDATE link SET bearing = 360 + bearing WHERE bearing < 0")
+
+
+def downgrade():
+    pass

--- a/meshinfo/collector.py
+++ b/meshinfo/collector.py
@@ -521,7 +521,8 @@ def bearing(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
         math.cos(lat1) * math.sin(lat2)
         - math.sin(lat1) * math.cos(lat2) * math.cos(lon_delta),
     )
-
+    if b < 0:
+        b = 2 * math.pi + b
     return round(math.degrees(b), 1)
 
 


### PR DESCRIPTION
Update calculation to always return positive bearings.  Use database migration to update existing values.

Fixes #92 