### PR TITLE
RF link color updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Changed
 ^^^^^^^
 
 * **BREAKING CHANGE:** Dropped support for Python 3.7 and 3.8.
+* Update RF link colors and style of infinite links (`#73 <https://github.com/smsearcy/mesh-info/issues/73>`_).
 
 Fixed
 ^^^^^

--- a/meshinfo/templates/components/map-legend.jinja2
+++ b/meshinfo/templates/components/map-legend.jinja2
@@ -1,9 +1,10 @@
 <div class="box p-1 m-1 is-hidden-mobile" x-data="{ show: true }">
   <div class="p-1 has-text-weight-bold" style="width: 12rem;" :class="{ 'is-hidden': !show }">
-    <div class="is-clearfix mb-3 has-text-centered" style="background: linear-gradient(to right, hsl(120, 100%, 50%), hsl(60, 100%, 50%), hsl(0, 100%, 50%))">
-      <div class="is-pulled-left ml-4 has-text-white">1</div>
-      RF Link Cost
-      <div class="is-pulled-right mr-4 has-text-white">10</div>
+    <div class="has-text-centered">RF Link Cost</div>
+    <div class="columns has-text-centered has-text-white m-0 mb-2">
+      {% for label, color in link_colors.items() %}
+      <div class="column p-1" style="background-color: {{ color }};">{{ label }}</div>
+      {% endfor %}
     </div>
     <div class="columns">
       <div class="column">
@@ -16,8 +17,8 @@
       <div class="column has-text-centered has-text-white">
         <div class="block mb-1" style="background: #3388ff; border-radius: 0.2rem;">DTD Link</div>
         <div class="block mb-1" style="background: #707070; border-radius: 0.2rem;">Tunnel</div>
-        <div class="block mb-1" style="background: #8b0000; border-radius: 0.2rem;">Unknown</div>
         <div class="block mb-1" style="background: #000000; border-radius: 0.2rem;">Infinite</div>
+        <div>&nbsp;</div>
         <div>&nbsp;</div>
         <div class="block is-clickable has-text-weight-normal has-text-dark" @click="show = ! show">Hide Legend</div>
       </div>

--- a/meshinfo/templates/pages/map.jinja2
+++ b/meshinfo/templates/pages/map.jinja2
@@ -79,6 +79,7 @@
               offset: feature.properties.offset,
               weight: feature.properties.weight,
               opacity: feature.properties.opacity,
+              dashArray: feature.properties.dashArray,
             }
           }
         });


### PR DESCRIPTION
Use discrete colors for the RF links, based on cost, instead of a gradient.  Use a palette that is accessible to color-blind people.

Closes #73