### PR TITLE
Fixes for missing IP addresses

### DIFF
--- a/meshinfo/aredn.py
+++ b/meshinfo/aredn.py
@@ -321,10 +321,10 @@ class SystemInfo:
         return ""
 
     @property
-    def wlan_interface(self) -> Optional[Interface]:
+    def primary_interface(self) -> Optional[Interface]:
         """Get the active wireless interface."""
         # is it worth using cached_property?
-        iface_names = ("wlan0", "wlan1", "eth0.3975", "eth1.3975")
+        iface_names = ("wlan0", "wlan1", "eth0.3975", "eth1.3975", "br-nomesh")
         for iface in iface_names:
             if iface not in self.interfaces or not self.interfaces[iface].ip_address:
                 continue
@@ -334,12 +334,14 @@ class SystemInfo:
             return None
 
     @property
-    def wlan_ip_address(self) -> str:
-        return getattr(self.wlan_interface, "ip_address", "")
+    def ip_address(self) -> str:
+        return getattr(self.primary_interface, "ip_address", "")
 
     @property
-    def wlan_mac_address(self) -> str:
-        return getattr(self.wlan_interface, "mac_address", "").replace(":", "").lower()
+    def mac_address(self) -> str:
+        return (
+            getattr(self.primary_interface, "mac_address", "").replace(":", "").lower()
+        )
 
     @property
     def band(self) -> Band:
@@ -403,7 +405,7 @@ class SystemInfo:
             return 0, 0
 
     def __str__(self):
-        return f"{self.node_name} ({self.wlan_ip_address})"
+        return f"{self.node_name} ({self.ip_address})"
 
 
 def load_system_info(json_data: Dict[str, Any]) -> SystemInfo:

--- a/meshinfo/collector.py
+++ b/meshinfo/collector.py
@@ -28,9 +28,9 @@ logger = structlog.get_logger()
 MODEL_TO_SYSINFO_ATTRS = {
     "name": "node_name",
     "display_name": "display_name",
-    "wlan_ip": "wlan_ip_address",
+    "ip_address": "ip_address",
     "description": "description",
-    "wlan_mac_address": "wlan_mac_address",
+    "mac_address": "mac_address",
     "up_time": "up_time",
     "up_time_seconds": "up_time_seconds",
     "load_averages": "load_averages",
@@ -345,7 +345,7 @@ def get_db_model(dbsession: Session, node: SystemInfo) -> Node | None:
     """Get the best match database record for this node."""
     # Find the most recently seen node that matches both name and MAC address
     query = dbsession.query(Node).filter(
-        Node.wlan_mac_address == node.wlan_mac_address,
+        Node.mac_address == node.mac_address,
         Node.name == node.node_name,
     )
     model = _get_most_recent(query.all())
@@ -354,7 +354,7 @@ def get_db_model(dbsession: Session, node: SystemInfo) -> Node | None:
 
     # Find active node with same hardware
     query = dbsession.query(Node).filter(
-        Node.wlan_mac_address == node.wlan_mac_address, Node.status == NodeStatus.ACTIVE
+        Node.mac_address == node.mac_address, Node.status == NodeStatus.ACTIVE
     )
     model = _get_most_recent(query.all())
     if model:

--- a/meshinfo/collector.py
+++ b/meshinfo/collector.py
@@ -354,7 +354,9 @@ def get_db_model(dbsession: Session, node: SystemInfo) -> Node | None:
 
     # Find active node with same hardware
     query = dbsession.query(Node).filter(
-        Node.mac_address == node.mac_address, Node.status == NodeStatus.ACTIVE
+        Node.mac_address == node.mac_address,
+        Node.status == NodeStatus.ACTIVE,
+        Node.mac_address != "",
     )
     model = _get_most_recent(query.all())
     if model:

--- a/meshinfo/models/node.py
+++ b/meshinfo/models/node.py
@@ -26,12 +26,12 @@ class Node(Base):
     status = Column(Enum(NodeStatus, native_enum=False), nullable=False)
     display_name = Column(String(70), nullable=False)
 
-    # TODO: handle multiple IP addresses? (RF(s), DTD, tunnel)
-    wlan_ip = Column(String(15), nullable=False)
+    # store the wireless/primary IP address
+    ip_address = Column("wlan_ip", String(15), nullable=False)
     description = Column(Unicode(1024), nullable=False)
 
-    # store MAC addresses without colons
-    wlan_mac_address = Column(String(12), nullable=False)
+    # store the MAC address (without colons) corresponding the primary interface
+    mac_address = Column("wlan_mac_address", String(12), nullable=False)
 
     last_seen = Column(PDateTime(), nullable=False)
 
@@ -81,7 +81,7 @@ class Node(Base):
     links = relationship("Link", foreign_keys="Link.source_id", back_populates="source")
 
     # Is this premature optimization?
-    Index("idx_mac_name", wlan_mac_address, name)
+    Index("idx_mac_name", mac_address, name)
 
     @property
     def location(self) -> str:
@@ -96,4 +96,4 @@ class Node(Base):
         return f"<models.Node(id={self.id!r}, name={self.name!r})>"
 
     def __str__(self):
-        return f"{self.name} ({self.wlan_ip})"
+        return f"{self.name} ({self.ip_address})"

--- a/meshinfo/poller.py
+++ b/meshinfo/poller.py
@@ -313,7 +313,7 @@ class Poller:
             )
 
         try:
-            node_info = load_system_info(json_data)
+            node_info = load_system_info(json_data, ip_address=ip_address)
         except Exception as exc:
             return await self._handle_response_error(
                 ip_address, PollingError.PARSE_ERROR, response_text, exc

--- a/meshinfo/report.py
+++ b/meshinfo/report.py
@@ -102,7 +102,7 @@ async def network_info(node: str, poller: Poller) -> NetworkInfo:
 def pprint_node(node: SystemInfo, checker: VersionChecker):
     """Pretty print information about an AREDN node."""
     print(f"Name: {INFO}{node.node_name}{END}")
-    print(f"WLAN IP: {INFO}{node.wlan_ip_address}{END}\tMAC: {node.wlan_mac_address}")
+    print(f"IP: {INFO}{node.ip_address}{END}\tMAC: {node.mac_address}")
     print(f"Model: {node.model}")
 
     firmware_color = VERSION_COLOR.get(checker.firmware(node.firmware_version), WARN)

--- a/meshinfo/templates/pages/node-details.jinja2
+++ b/meshinfo/templates/pages/node-details.jinja2
@@ -54,7 +54,7 @@
       </div>
       <div class="mb-2">
         <div class="heading">IP Address</div>
-        <div>{{ node.wlan_ip }}</div>
+        <div>{{ node.ip_address }}</div>
       </div>
       <div class="mb-2">
         <div class="heading">Up Time</div>

--- a/meshinfo/templates/pages/nodes.jinja2
+++ b/meshinfo/templates/pages/nodes.jinja2
@@ -30,7 +30,7 @@
           name: 'Name',
           formatter: (cell, row) => gridjs.html(`<a href='${row.cells[0].data}'>${cell}</a>`)
         },
-        'WLAN IP',
+        'IP Address',
         'Status',
         'SSID',
         'Band',
@@ -79,7 +79,7 @@
           [
             '{{ req.route_url("node-details", id=node.id) }}',
             '{{ node.display_name }}',
-            '{{ node.wlan_ip }}',
+            '{{ node.ip_address }}',
             '{{ node.status }}',
             '{{ node.ssid }}',
             '{{ node.band }}',

--- a/meshinfo/views/nodes.py
+++ b/meshinfo/views/nodes.py
@@ -32,7 +32,7 @@ class NodeListViews:
         csv_out.writerow(
             (
                 "Name",
-                "WLAN IP",
+                "IP Address",
                 "Status",
                 "Band",
                 "Channel",
@@ -48,7 +48,7 @@ class NodeListViews:
             csv_out.writerow(
                 (
                     node.name,
-                    node.wlan_ip,
+                    node.ip_address,
                     node.status,
                     node.band,
                     node.channel,

--- a/tests/test_aredn.py
+++ b/tests/test_aredn.py
@@ -22,7 +22,7 @@ def test_parse_all_sysinfo_examples(filename):
     assert system_info is not None
 
     # Make sure we identified the wireless IP address
-    assert system_info.wlan_ip_address
+    assert system_info.ip_address
 
 
 def test_api_version_1_0(data_folder):
@@ -98,7 +98,7 @@ def test_api_version_1_6(data_folder):
     assert system_info.up_time_seconds == 22_042_803
     assert system_info.active_tunnel_count == 0
     assert len(system_info.services) == 1
-    assert system_info.wlan_ip_address == "10.159.123.176"
+    assert system_info.ip_address == "10.159.123.176"
     assert system_info.band == Band.TWO_GHZ
 
 
@@ -126,7 +126,7 @@ def test_api_version_1_7(data_folder):
     assert system_info.up_time == "3 days, 19:44:05"
     assert system_info.up_time_seconds == 330_245
     assert system_info.active_tunnel_count == 0
-    assert system_info.wlan_ip_address == "10.106.204.11"
+    assert system_info.ip_address == "10.106.204.11"
     assert system_info.band == Band.FIVE_GHZ
 
 
@@ -154,7 +154,7 @@ def test_api_version_1_9(data_folder):
     assert system_info.up_time == "7 days, 14:51:22"
     assert system_info.up_time_seconds == 658282
     assert system_info.active_tunnel_count == 0
-    assert system_info.wlan_ip_address == "10.10.115.143"
+    assert system_info.ip_address == "10.10.115.143"
     assert system_info.band == Band.TWO_GHZ
     assert len(system_info.links) == 1
 
@@ -193,7 +193,7 @@ def test_tunnel_only_1_6(data_folder):
     assert system_info.api_version == "1.6"
     assert len(system_info.load_averages) == 3
     assert system_info.active_tunnel_count == 11
-    assert system_info.wlan_ip_address == "10.154.255.82"
+    assert system_info.ip_address == "10.154.255.82"
     assert system_info.lan_ip_address == "10.215.250.145"
 
 
@@ -214,7 +214,7 @@ def test_with_tunnel_1_7(data_folder):
     assert system_info.api_version == "1.7"
     assert len(system_info.load_averages) == 3
     assert system_info.active_tunnel_count == 0
-    assert system_info.wlan_ip_address == "10.1.2.3"
+    assert system_info.ip_address == "10.1.2.3"
     assert system_info.lan_ip_address == "10.3.2.1"
 
 
@@ -235,10 +235,10 @@ def test_wlan_mac_address_standardization(data_folder):
         json_data = json.load(f)
     system_info = aredn.load_system_info(json_data)
 
-    wlan_interface = system_info.wlan_interface
-    assert wlan_interface.mac_address != system_info.wlan_mac_address
-    assert ":" not in system_info.wlan_mac_address
-    assert system_info.wlan_mac_address == system_info.wlan_mac_address.lower()
+    wlan_interface = system_info.primary_interface
+    assert wlan_interface.mac_address != system_info.mac_address
+    assert ":" not in system_info.mac_address
+    assert system_info.mac_address == system_info.mac_address.lower()
 
 
 def test_radio_link_info_parsing(data_folder):


### PR DESCRIPTION
Get the primary IP address from the JSON data for newer firmware when RF is disabled.

Use the IP address the poller connected to as a fallback when the primary/WLAN interface cannot be identified.

Fixes #111