### PR TITLE
Refactor network poller

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run flake8
         run: flake8 meshinfo tests
       - name: Run mypy
-        run: mypy meshinfo
+        run: mypy meshinfo tests
       - name: Run pytest
         run: pytest --cov=meshinfo
         env:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,11 @@ Changed
 
 * **BREAKING CHANGE:** Dropped support for Python 3.7 and 3.8.
 * Update RF link colors and style of infinite links (`#73 <https://github.com/smsearcy/mesh-info/issues/73>`_).
-* Reduce logging output (`#107 <https://github.com/smsearcy/mesh-info/issues/107>`_).
+* **BREAKING CHANGE:** Logging levels ``TRACE`` and ``SUCCESS`` have been removed, ``WARNING`` is the new default (`#107 <https://github.com/smsearcy/mesh-info/issues/107>`_).
+* **BREAKING CHANGE:** Renamed configuration variables for count of network pollers and polling timeout. (`#113 <https://github.com/smsearcy/mesh-info/issues/113>`_).
+
+  * ``MESH_INFO_COLLECTOR_WORKERS`` replaces ``MESH_INFO_POLLER_MAX_CONNECTIONS``.
+  * ``MESH_INFO_COLLECTOR_TIMEOUT`` replaces ``MESH_INFO_POLLER_CONNECT_TIMEOUT`` and ``MESH_INFO_POLLER_READ_TIMEOUT`` with a single, total timeout.
 
 Fixed
 ^^^^^

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 	flake8 meshinfo tests
 
 mypy:
-	mypy meshinfo
+	mypy meshinfo tests
 
 tests:
 	pytest --cov=meshinfo --cov-report html --cov-report term

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -20,6 +20,10 @@ Example
 Options
 -------
 
+.. note::
+
+   The options for ``meshinfo report`` are configured on the command line.
+
 MESH_INFO_COLLECTOR_LINK_INACTIVE
    Number of days a link remains on the map in inactive state after it was last seen.
    Default is 1 day.
@@ -27,6 +31,14 @@ MESH_INFO_COLLECTOR_LINK_INACTIVE
 MESH_INFO_COLLECTOR_NODE_INACTIVE
    Number of days a node remains on the map in inactive state after it was last seen.
    Default is 7 days.
+
+MESH_INFO_COLLECTOR_TIMEOUT
+   Total number of seconds to fetch ``sysinfo.json`` information before timing out.
+   Default is 30.
+
+MESH_INFO_COLLECTOR_WORKERS
+   Number of worker tasks polling the network simultaneously.
+   Default is 50.
 
 MESH_INFO_DB_URL
    Override the default SQLite database by pointing to a PostgreSQL server
@@ -44,8 +56,8 @@ MESH_INFO_LOCAL_NODE
 MESH_INFO_LOG_LEVEL
    Controls how much information is logged/displayed in terminal.
    Can be one of the following (from most verbose to least):
-   ``TRACE``, ``DEBUG``, ``INFO``, ``SUCCESS``, ``WARNING``, ``ERROR``.
-   Default is ``SUCCESS``.
+   ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``.
+   Default is ``WARNING``.
 
 MESH_INFO_MAP_LATITUDE
    Latitude coordinate to center map on.
@@ -77,20 +89,6 @@ MESH_INFO_MAP_TILE_URL
 MESH_INFO_MAP_ZOOM
    Default zoom level.
    Passed to `Leaflet <https://leafletjs.com/>`_.
-
-MESH_INFO_POLLER_CONNECT_TIMEOUT
-   Number of seconds to establish a connection to a node when polling the network.
-   Decrease to speed up network polling at the risk of having more nodes timeout.
-   Default is 10.
-
-MESH_INFO_POLLER_MAX_CONNECTIONS
-   Maximum number of simultaneous outgoing polling connections.
-   Default is 50.
-
-MESH_INFO_POLLER_READ_TIMEOUT
-   Number of seconds to read data from node before timing out.
-   Decrease to speed up network polling at the risk of having more nodes timeout.
-   Default is 15.
 
 MESH_INFO_WEB_BIND
    TCP or Unix socket to bind web application to.

--- a/meshinfo/poller.py
+++ b/meshinfo/poller.py
@@ -16,10 +16,10 @@ import enum
 import json
 import re
 import time
-from asyncio import StreamReader
-from collections import abc, defaultdict, deque
-from collections.abc import Iterable, Iterator
-from typing import Awaitable, NamedTuple
+from asyncio import Queue, StreamReader
+from collections import defaultdict, deque
+from collections.abc import Iterator
+from typing import NamedTuple
 
 import aiohttp
 import attrs
@@ -27,6 +27,7 @@ import structlog
 from structlog import contextvars
 
 from .aredn import LinkInfo, SystemInfo, load_system_info
+from .network import reverse_dns_lookup
 from .types import LinkType
 
 logger = structlog.get_logger()
@@ -65,8 +66,47 @@ class Topology:
             yield from links
 
 
+class NetworkInfo(NamedTuple):
+    """Combined results of querying the nodes and links on the network."""
+
+    nodes: deque[SystemInfo]
+    links: deque[LinkInfo]
+    errors: deque[NodeError]
+
+
+class PollingError(enum.Enum):
+    """Enumerates possible errors when polling a node."""
+
+    INVALID_RESPONSE = enum.auto()
+    PARSE_ERROR = enum.auto()
+    CONNECTION_ERROR = enum.auto()
+    HTTP_ERROR = enum.auto()
+    TIMEOUT_ERROR = enum.auto()
+
+    def __str__(self):
+        if "HTTP" in self.name:
+            # keep the acronym all uppercase
+            return "HTTP Error"
+        return self.name.replace("_", " ").title()
+
+
+@attrs.define
+class NodeError:
+    ip_address: str
+    name: str
+    error: PollingError
+    response: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.name or 'name unknown'} ({self.ip_address})"
+
+    def __str__(self):
+        return f"{self.error} ('{self.response[10:]}...')"
+
+
 async def topology_from_olsr(
-    host_name: str = "localnode.local.mesh", port: int = 2004, timeout: int = 5
+    host_name: str, port: int = 2004, timeout: int = 5
 ) -> Topology:
     """Load a model of the topology from the OLSR daemon.
 
@@ -126,252 +166,207 @@ async def _process_olsr_data(reader: StreamReader) -> Topology:
     return topology
 
 
-@attrs.define
-class Poller:
-    max_connections: int
-    timeout: aiohttp.ClientTimeout
-    lookup_name: abc.Callable[[str], Awaitable[str]]
+async def poll_network(
+    *,
+    start_node: str,
+    timeout: int,
+    workers: int,
+    dns_server: str = "",
+) -> NetworkInfo:
+    """Loads topology data from the specified node and then polls the network.
 
-    @classmethod
-    def create(
-        cls,
-        lookup_name: abc.Callable[[str], Awaitable[str]],
-        max_connections: int = 50,
-        connect_timeout: int = 10,
-        read_timeout: int = 15,
-    ) -> Poller:
-        """Initialize a `Poller` object."""
-        return Poller(
-            lookup_name=lookup_name,
-            max_connections=max_connections,
-            timeout=aiohttp.ClientTimeout(
-                sock_connect=connect_timeout,
-                sock_read=read_timeout,
-            ),
-        )
+    Returns:
+        System information for all successfully parsed nodes,
+        link information for all the links,
+        and errors encountered contacting/parsing node data.
 
-    async def get_network_info(self, topology: Topology) -> NetworkInfo:
-        """Gets the node and link information about the network."""
+    """
+    topology = await topology_from_olsr(start_node)
 
-        # start processing the nodes
-        node_task = asyncio.create_task(self._poll_nodes(topology.nodes))
-        # wait for the nodes to finish processing
-        node_results: list[NodeResult] = await node_task
+    dns_server = dns_server or start_node
 
-        # make a dictionary for quick lookups of node name from IP address
-        # (for cross-referencing with OLSR data)
-        ip_name_map = {
-            node.ip_address: node.name
-            for node in node_results
-            if all((node.name, node.ip_address))
-        }
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    for ip_address in topology.nodes:
+        queue.put_nowait(ip_address)
 
-        count: defaultdict[str, int] = defaultdict(int)
-        # Collect the list of node `SystemInfo` objects to return
-        nodes: deque[SystemInfo] = deque()
-        # Build list of links for all nodes, using AREDN data, falling back to OLSR
-        links: deque[LinkInfo] = deque()
-        node_errors: deque[NodeResult] = deque()
-        for node in node_results:
-            count["node results"] += 1
-            if node.error:
-                count["errors (totals)"] += 1
-                count[f"errors ({node.error.error!s})"] += 1
-                node_errors.append(node)
-                continue
+    results = NetworkInfo(deque(), deque(), deque())
 
-            sys_info = node.system_info
-            if sys_info is None:
-                logger.error("Node does not have response or error", node=node)
-                continue
-            nodes.append(sys_info)
-            if len(sys_info.links) > 0:
-                # Use link information from AREDN if we have it (newer firmware)
-                count["using link_info json"] += 1
-                if sys_info.api_version_tuple < (1, 9):
-                    # get the link cost from OLSR (pre-v1.9 API)
-                    count["using olsr for link cost"] += 1
-                    _populate_link_cost_from_topography(
-                        sys_info.links,
-                        topology.links_by_source.get(node.ip_address, set()),
+    async with aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(limit=0),
+        timeout=aiohttp.ClientTimeout(total=timeout),
+    ) as session:
+        start_time = time.monotonic()
+        worker_tasks = []
+        for id_ in range(workers):
+            with contextvars.bound_contextvars(worker=id_):
+                worker_tasks.append(
+                    asyncio.create_task(
+                        _node_polling_worker(queue, results, session, dns_server)
                     )
-                links.extend(sys_info.links)
-                sys_info.link_count = len(sys_info.links)
-                continue
+                )
 
+        await queue.join()
+        crawler_elapsed = time.monotonic() - start_time
+
+        for task in worker_tasks:
+            task.cancel()
+
+        await asyncio.gather(*worker_tasks, return_exceptions=True)
+        logger.info("Querying nodes finished", elapsed=crawler_elapsed)
+
+    # make a dictionary for quick lookups of node name from IP address
+    # (for cross-referencing with OLSR data)
+    ip_name_map = {
+        node.ip_address: node.node_name
+        for node in results.nodes
+        if all((node.node_name, node.ip_address))
+    }
+
+    count: defaultdict[str, int] = defaultdict(int)
+    for error in results.errors:
+        if all((error.name, error.ip_address)):
+            ip_name_map[error.ip_address] = error.name
+        count["errors (totals)"] += 1
+        count[f"errors ({error.error!s})"] += 1
+
+    for sys_info in results.nodes:
+        count["node results"] += 1
+
+        if len(sys_info.links) == 0:
             # Create `LinkInfo` objects based on the information in OLSR
             # **This should only necessary for firmware < API 1.7**
             count["using olsr for link data"] += 1
-            sys_info.link_count = 0
-            try:
-                node_olsr_links = topology.links_by_source[node.ip_address]
-            except KeyError:
-                logger.warning(
-                    "Failed to find OLSR link(s)",
-                    system_info=sys_info,
-                    ip_address=node.ip_address,
-                )
-                continue
-            for link in node_olsr_links:
-                sys_info.link_count += 1
-                if link.destination not in ip_name_map:
-                    logger.warning(
-                        "OLSR IP not found in node information, skipping",
-                        link=link,
-                    )
-                    continue
-                links.append(
-                    LinkInfo(
-                        source=sys_info.node_name,
-                        destination=ip_name_map[link.destination],
-                        destination_ip=link.destination,
-                        type=LinkType.UNKNOWN,
-                        interface="unknown",
-                        olsr_cost=link.cost,
-                    )
-                )
+            results.links.extend(
+                _create_link_info_from_topology(sys_info, topology, ip_name_map)
+            )
+            continue
 
-        logger.info("Finished loading network data", summary=dict(count))
+        # Use link information from AREDN if we have it (API >= 1.7)
+        count["using link_info json"] += 1
+        if sys_info.api_version_tuple < (1, 9):
+            # get the link cost from OLSR (pre-v1.9 API)
+            count["using olsr for link cost"] += 1
+            _populate_link_cost_from_topography(
+                sys_info.links,
+                topology.links_by_source.get(sys_info.ip_address, set()),
+            )
+        results.links.extend(sys_info.links)
+        sys_info.link_count = len(sys_info.links)
+        continue
 
-        return NetworkInfo(nodes, links, node_errors)
+    logger.info("Finished loading network data", summary=dict(count))
+    return results
 
-    async def _poll_nodes(self, addresses: Iterable[str]) -> list[NodeResult]:
-        """Get information about all the nodes in the network."""
+
+async def _node_polling_worker(
+    queue: Queue, results: NetworkInfo, session: aiohttp.ClientSession, dns_server: str
+) -> None:
+    """Asynchronous worker to process nodes from the queue and poll them."""
+    while True:
+        ip_address = await queue.get()
         start_time = time.monotonic()
+        with contextvars.bound_contextvars(node_ip=ip_address):
+            logger.debug("Began polling")
+            node_info = await _poll_node(ip_address, session, dns_server=dns_server)
+            elapsed = time.monotonic() - start_time
+            if isinstance(node_info, SystemInfo):
+                logger.debug(
+                    "Finished polling", name=node_info.node_name, elapsed=elapsed
+                )
+                results.nodes.append(node_info)
+            else:
+                logger.debug(
+                    "Finished polling (with errors)",
+                    name=node_info.name,
+                    elapsed=elapsed,
+                )
+                results.errors.append(node_info)
+        queue.task_done()
 
-        tasks = []
-        connector = aiohttp.TCPConnector(limit=self.max_connections)
-        async with aiohttp.ClientSession(
-            timeout=self.timeout, connector=connector
-        ) as session:
-            for address in addresses:
-                with contextvars.bound_contextvars(ip=address):
-                    task = asyncio.create_task(
-                        self._poll_node(address, session=session)
-                    )
-                    # Since aiohttp is handling limits,
-                    # these all get created at the beginning,
-                    # not close to when they are actually processed.
-                    # logger.debug("Created polling task")
-                    tasks.append(task)
 
-            # collect all the results in a single list, dropping any exceptions
-            node_results = []
-            for result in await asyncio.gather(*tasks, return_exceptions=True):
-                if isinstance(result, Exception):
-                    logger.error("Unexpected exception polling nodes", error=result)
-                    continue
-                node_results.append(result)
+async def _poll_node(
+    ip_address: str, session: aiohttp.ClientSession, *, dns_server: str
+) -> SystemInfo | NodeError:
+    """Fetch a node's ``sysinfo.json`` and attempt to parse the response."""
+    params = {"services_local": 1, "link_info": 1}
+    try:
+        async with session.get(
+            f"http://{ip_address}:8080/cgi-bin/sysinfo.json", params=params
+        ) as resp:
+            logger.debug("HTTP response received")
+            status = resp.status
+            response = await resp.read()
+            # copy and pasting Unicode seems to create an invalid description
+            # example we had was b"\xb0" for a degree symbol
+            response_text = response.decode("utf-8", "replace")
+    except asyncio.TimeoutError as exc:
+        node_name = await reverse_dns_lookup(ip_address, dns_server)
+        logger.warning("Connection timeout", name=node_name, exc=exc)
+        return NodeError(ip_address, node_name, PollingError.TIMEOUT_ERROR, str(exc))
+    except aiohttp.ClientError as exc:
+        node_name = await reverse_dns_lookup(ip_address, dns_server)
+        logger.warning("Connection error", name=node_name, exc=exc)
+        return NodeError(ip_address, node_name, PollingError.CONNECTION_ERROR, str(exc))
+    except Exception as exc:
+        node_name = await reverse_dns_lookup(ip_address, dns_server)
+        logger.warning("Unknown error", name=node_name, exc=exc)
+        return NodeError(ip_address, node_name, PollingError.CONNECTION_ERROR, str(exc))
 
-        crawler_finished = time.monotonic()
-        logger.info("Querying nodes finished", elapsed=crawler_finished - start_time)
-        return node_results
+    if status != 200:
+        message = f"{status}: {response_text}"
+        node_name = await reverse_dns_lookup(ip_address, dns_server)
+        logger.warning("HTTP error", name=node_name, response=message)
+        return NodeError(ip_address, node_name, PollingError.HTTP_ERROR, message)
 
-    async def _poll_node(
-        self, ip_address: str, *, session: aiohttp.ClientSession
-    ) -> NodeResult:
-        """Query a node via HTTP to get the information about that node.
-
-        Args:
-            session: aiohttp session object
-                (docs recommend to pass around single object)
-            ip_address: IP address of the node to query
-
-        Returns:
-            Named tuple with the IP address,
-            result of either `SystemInfo` or `NodeError`,
-            and the raw response string.
-
-        """
-
-        params = {"services_local": 1, "link_info": 1}
-
-        try:
-            async with session.get(
-                f"http://{ip_address}:8080/cgi-bin/sysinfo.json", params=params
-            ) as resp:
-                logger.debug("HTTP response received")
-                status = resp.status
-                response = await resp.read()
-                # copy and pasting Unicode seems to create an invalid description
-                # example we had was b"\xb0" for a degree symbol
-                response_text = response.decode("utf-8", "replace")
-        except Exception as exc:
-            return await self._handle_connection_error(ip_address, exc)
-
-        if status != 200:
-            message = f"{status}: {response_text}"
-            return await self._handle_response_error(
-                ip_address, PollingError.HTTP_ERROR, message
-            )
-
-        try:
-            json_data = json.loads(response_text)
-        except json.JSONDecodeError as exc:
-            return await self._handle_response_error(
-                ip_address, PollingError.INVALID_RESPONSE, response_text, exc
-            )
-
-        try:
-            node_info = load_system_info(json_data, ip_address=ip_address)
-        except Exception as exc:
-            return await self._handle_response_error(
-                ip_address, PollingError.PARSE_ERROR, response_text, exc
-            )
-
-        logger.debug("Finished polling", name=node_info.node_name)
-        return NodeResult(
-            ip_address=ip_address,
-            name=node_info.node_name,
-            system_info=node_info,
+    try:
+        json_data = json.loads(response_text)
+    except json.JSONDecodeError as exc:
+        node_name = await reverse_dns_lookup(ip_address, dns_server)
+        logger.warning("Invalid JSON response", name=node_name, exc=exc)
+        return NodeError(
+            ip_address, node_name, PollingError.INVALID_RESPONSE, response_text
         )
 
-    async def _handle_connection_error(
-        self, ip_address: str, exc: Exception
-    ) -> NodeResult:
-        result = NodeResult(
-            ip_address=ip_address,
-            name=await self.lookup_name(ip_address),
+    try:
+        node_info = load_system_info(json_data, ip_address=ip_address)
+    except Exception as exc:
+        node_name = await reverse_dns_lookup(ip_address, dns_server)
+        logger.warning("Parsing node information failed", name=node_name, exc=exc)
+        return NodeError(ip_address, node_name, PollingError.PARSE_ERROR, response_text)
+
+    return node_info
+
+
+def _create_link_info_from_topology(
+    sys_info: SystemInfo, topology: Topology, ip_name_map: dict[str, str]
+) -> Iterator[LinkInfo]:
+    """Yield link information from the topology data for older firmware versions."""
+    sys_info.link_count = 0
+    try:
+        node_olsr_links = topology.links_by_source[sys_info.ip_address]
+    except KeyError:
+        logger.warning(
+            "Failed to find OLSR link(s)",
+            system_info=sys_info,
+            ip_address=sys_info.ip_address,
         )
-        contextvars.bind_contextvars(node=result.name)
-
-        # py3.10 - use match operator?
-        if isinstance(exc, asyncio.TimeoutError):
-            # catch this first, because some exceptions use multiple inheritance
-            logger.warning("Connection timeout", exc=exc)
-            result.error = NodeError(PollingError.TIMEOUT_ERROR, "Timeout error")
-        elif isinstance(exc, aiohttp.ClientError):
-            logger.warning("Connection error", exc=exc)
-            result.error = NodeError(PollingError.CONNECTION_ERROR, str(exc))
-        else:
-            logger.warning("Unknown error", exc=exc)
-            result.error = NodeError(PollingError.CONNECTION_ERROR, str(exc))
-
-        return result
-
-    async def _handle_response_error(
-        self,
-        ip_address: str,
-        error: PollingError,
-        response: str,
-        exc: Exception | None = None,
-    ) -> NodeResult:
-        node_name = await self.lookup_name(ip_address)
-        result = NodeResult(ip_address=ip_address, name=node_name)
-        contextvars.bind_contextvars(node=node_name)
-
-        # py3.10 - use match operator?
-        if error == PollingError.HTTP_ERROR:
-            logger.warning("HTTP error", response=response)
-            result.error = NodeError(PollingError.HTTP_ERROR, response)
-        elif error == PollingError.INVALID_RESPONSE:
-            logger.warning("Invalid JSON response", exc=exc)
-            result.error = NodeError(PollingError.INVALID_RESPONSE, response)
-        elif error == PollingError.PARSE_ERROR:
-            logger.warning("Parsing node information failed", exc=exc)
-            result.error = NodeError(PollingError.PARSE_ERROR, response)
-
-        return result
+        return
+    for link in node_olsr_links:
+        sys_info.link_count += 1
+        if link.destination not in ip_name_map:
+            logger.warning(
+                "OLSR IP not found in node information, skipping",
+                link=link,
+            )
+            continue
+        yield LinkInfo(
+            source=sys_info.node_name,
+            destination=ip_name_map[link.destination],
+            destination_ip=link.destination,
+            type=LinkType.UNKNOWN,
+            interface="unknown",
+            olsr_cost=link.cost,
+        )
 
 
 def _populate_link_cost_from_topography(
@@ -386,53 +381,3 @@ def _populate_link_cost_from_topography(
         if link.destination_ip not in cost_by_destination:
             continue
         link.olsr_cost = cost_by_destination[link.destination_ip]
-
-
-class NetworkInfo(NamedTuple):
-    """Combined results of querying the nodes and links on the network.
-
-    Errors are stored as a dictionary, indexed by the IP address and storing the error
-    and any message in a tuple.
-
-    """
-
-    nodes: deque[SystemInfo]
-    links: deque[LinkInfo]
-    errors: deque[NodeResult]
-
-
-@attrs.define
-class NodeError:
-    error: PollingError
-    response: str
-
-    def __str__(self):
-        return f"{self.error} ('{self.response[10:]}...')"
-
-
-class PollingError(enum.Enum):
-    """Enumerates possible errors when polling a node."""
-
-    INVALID_RESPONSE = enum.auto()
-    PARSE_ERROR = enum.auto()
-    CONNECTION_ERROR = enum.auto()
-    HTTP_ERROR = enum.auto()
-    TIMEOUT_ERROR = enum.auto()
-
-    def __str__(self):
-        if "HTTP" in self.name:
-            # keep the acronym all uppercase
-            return "HTTP Error"
-        return self.name.replace("_", " ").title()
-
-
-@attrs.define
-class NodeResult:
-    ip_address: str
-    name: str
-    system_info: SystemInfo | None = None
-    error: NodeError | None = None
-
-    @property
-    def label(self) -> str:
-        return f"{self.name or 'name unknown'} ({self.ip_address})"

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,5 +18,11 @@ ignore_missing_imports = True
 [mypy-sqlalchemy.*]
 ignore_missing_imports = True
 
+[mypy-transaction.*]
+ignore_missing_imports = True
+
+[mypy-webtest.*]
+ignore_missing_imports = True
+
 [mypy-zope.*]
 ignore_missing_imports = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,13 +21,13 @@ def test_config():
             "MESH_INFO_ENV": "development",
             "MESH_INFO_LOG_LEVEL": "DEBUG",
             "MESH_INFO_DB_URL": "foobar",
-            "MESH_INFO_POLLER_MAX_CONNECTIONS": "25",
+            "MESH_INFO_COLLECTOR_WORKERS": "25",
             "MESH_INFO_COLLECTOR_NODE_INACTIVE": "25",
         }
     )
 
+    assert app_config.collector.node_inactive == 25
+    assert app_config.collector.workers == 25
+    assert app_config.db.url == "foobar"
     assert app_config.env == Environment.DEV
     assert app_config.log_level == logging.DEBUG
-    assert app_config.db.url == "foobar"
-    assert app_config.poller.max_connections == 25
-    assert app_config.collector.node_inactive == 25


### PR DESCRIPTION
Refactor the network poller to use a pool of `asyncio` worker tasks that pull nodes from a queue and query them.  I think this is a more standard method of doing async tasks (e.g. matches other languages and means we can use Python 3.11's `asyncio.TaskGroup` in the future).  This also provides more control over the parallelization than relying on *aiohttp*'s worker management and better logging of what workers are doing.  And I think that the "connect" timeout might have penalized the poller for time waiting for a connection in the pool, causing more timeouts.

Closes #105