### PR TITLE
Get list of network nodes from JSON API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.15.4
+    rev: 2.22.3
     hooks:
       # Ensure lock file is consistent with pyproject.toml
       - id: pdm-lock-check

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,11 +28,17 @@ Changed
 
 * Use updated RRDtool Python bindings package
 * Switched development tooling to use PDM and Ruff
+* Updated latest AREDN version to 3.25.2.0
 
 Removed
 ^^^^^^^
 
 * **BREAKING CHANGE:** Removed support for PostgreSQL.
+
+Fixed
+^^^^^
+
+* Support AREDN 3.25.2.0 by using OLSR topology information as a fallback.
 
 0.7.0 - 2024-05-20
 ------------------

--- a/meshinfo/config.py
+++ b/meshinfo/config.py
@@ -45,7 +45,7 @@ def _get_log_level(level: str) -> int:
 class AppConfig:
     @environ.config
     class Aredn:
-        current_firmware: str = environ.var(default="3.24.6.0")
+        current_firmware: str = environ.var(default="3.25.2.0")
         current_api: str = environ.var(default="1.13")
 
     @environ.config

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,13 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "dev", "testing", "docs", "ruff", "mypy"]
-strategy = ["cross_platform", "inherit_metadata"]
-lock_version = "4.4.1"
-content_hash = "sha256:4b8ff74990a172efeddd003535b30d546a7a522a061f25ebfdacbdddeae40de3"
+groups = ["default", "dev", "docs", "mypy", "ruff", "testing"]
+strategy = ["inherit_metadata"]
+lock_version = "4.5.0"
+content_hash = "sha256:9875d14ed6248c4dfbed5ba2925e419ce148b5bdcf83382c5bce88dbc1481b9a"
+
+[[metadata.targets]]
+requires_python = ">=3.9"
 
 [[package]]
 name = "aiohttp"
@@ -119,6 +122,8 @@ groups = ["default"]
 dependencies = [
     "Mako",
     "SQLAlchemy>=1.3.0",
+    "importlib-metadata; python_version < \"3.9\"",
+    "importlib-resources; python_version < \"3.9\"",
     "typing-extensions>=4",
 ]
 files = [
@@ -133,6 +138,9 @@ requires_python = ">=3.7"
 summary = "Timeout context manager for asyncio programs"
 groups = ["default"]
 marker = "python_version < \"3.11\""
+dependencies = [
+    "typing-extensions>=3.6.5; python_version < \"3.8\"",
+]
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
     {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
@@ -144,6 +152,9 @@ version = "23.2.0"
 requires_python = ">=3.7"
 summary = "Classes Without Boilerplate"
 groups = ["default"]
+dependencies = [
+    "importlib-metadata; python_version < \"3.8\"",
+]
 files = [
     {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
     {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
@@ -155,6 +166,9 @@ version = "2.15.0"
 requires_python = ">=3.8"
 summary = "Internationalization utilities"
 groups = ["docs"]
+dependencies = [
+    "pytz>=2015.7; python_version < \"3.9\"",
+]
 files = [
     {file = "Babel-2.15.0-py3-none-any.whl", hash = "sha256:08706bdad8d0a3413266ab61bd6c34d0c28d6e1e7badf40a2cebe67644e2e1fb"},
     {file = "babel-2.15.0.tar.gz", hash = "sha256:8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413"},
@@ -415,6 +429,7 @@ summary = "Boilerplate-free configuration with env variables."
 groups = ["default"]
 dependencies = [
     "attrs>=17.4.0",
+    "importlib-metadata; python_version < \"3.8\"",
 ]
 files = [
     {file = "environ_config-23.2.0-py3-none-any.whl", hash = "sha256:20a60f90a0a9e80d7d5ed92060a8fbb9b7b016ba34bda85361ec376340013be9"},
@@ -584,6 +599,7 @@ requires_python = ">=3.7"
 summary = "WSGI HTTP Server for UNIX"
 groups = ["default"]
 dependencies = [
+    "importlib-metadata; python_version < \"3.8\"",
     "packaging",
 ]
 files = [
@@ -643,6 +659,7 @@ summary = "Read metadata from Python packages"
 groups = ["docs"]
 marker = "python_version < \"3.10\""
 dependencies = [
+    "typing-extensions>=3.6.4; python_version < \"3.8\"",
     "zipp>=0.5",
 ]
 files = [
@@ -910,6 +927,9 @@ version = "3.1.0"
 requires_python = ">=3.7"
 summary = "Load, configure, and compose WSGI applications and servers"
 groups = ["default", "dev"]
+dependencies = [
+    "importlib-metadata; python_version < \"3.8\"",
+]
 files = [
     {file = "PasteDeploy-3.1.0-py3-none-any.whl", hash = "sha256:76388ad53a661448d436df28c798063108f70e994ddc749540d733cdbd1b38cf"},
     {file = "PasteDeploy-3.1.0.tar.gz", hash = "sha256:9ddbaf152f8095438a9fe81f82c78a6714b92ae8e066bed418b6a7ff6a095a95"},
@@ -924,6 +944,7 @@ groups = ["default"]
 dependencies = [
     "python-dateutil<3.0,>=2.6",
     "pytzdata>=2020.1",
+    "typing<4.0,>=3.6; python_version < \"3.5\"",
 ]
 files = [
     {file = "pendulum-2.1.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:29c40a6f2942376185728c9a0347d7c0f07905638c83007e1d262781f1e6953a"},
@@ -937,6 +958,9 @@ version = "1.1.2"
 requires_python = ">=3.7"
 summary = "A loader interface around multiple config file formats."
 groups = ["default", "dev"]
+dependencies = [
+    "importlib-metadata; python_version < \"3.8\"",
+]
 files = [
     {file = "plaster-1.1.2-py2.py3-none-any.whl", hash = "sha256:42992ab1f4865f1278e2ad740e8ad145683bb4022e03534265528f0c23c0df2d"},
     {file = "plaster-1.1.2.tar.gz", hash = "sha256:f8befc54bf8c1147c10ab40297ec84c2676fa2d4ea5d6f524d9436a80074ef98"},
@@ -963,6 +987,9 @@ version = "2.6.2"
 requires_python = ">=3.7"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 groups = ["default", "dev"]
+dependencies = [
+    "typing-extensions>=4.4; python_version < \"3.8\"",
+]
 files = [
     {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
     {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
@@ -1038,6 +1065,7 @@ summary = "A package which provides an interactive HTML debugger for Pyramid app
 groups = ["dev"]
 dependencies = [
     "Pygments",
+    "importlib-metadata; python_version < \"3.8\"",
     "pyramid-mako>=0.3.1",
     "pyramid>=1.4",
 ]
@@ -1287,6 +1315,7 @@ groups = ["default"]
 dependencies = [
     "markdown-it-py>=2.2.0",
     "pygments<3.0.0,>=2.13.0",
+    "typing-extensions<5.0,>=4.0.0; python_version < \"3.9\"",
 ]
 files = [
     {file = "rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222"},
@@ -1507,6 +1536,7 @@ summary = "Database Abstraction Library"
 groups = ["default"]
 dependencies = [
     "greenlet!=0.4.17; (platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\") and python_version >= \"3\"",
+    "importlib-metadata; python_version < \"3.8\"",
 ]
 files = [
     {file = "SQLAlchemy-1.4.52-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:f68016f9a5713684c1507cc37133c28035f29925c75c0df2f9d0f7571e23720a"},
@@ -1625,6 +1655,7 @@ groups = ["dev"]
 dependencies = [
     "distlib<1,>=0.3.6",
     "filelock<4,>=3.4.1",
+    "importlib-metadata>=4.8.3; python_version < \"3.8\"",
     "platformdirs<4,>=2.4",
 ]
 files = [
@@ -1693,6 +1724,7 @@ groups = ["default"]
 dependencies = [
     "idna>=2.0",
     "multidict>=4.0",
+    "typing-extensions>=3.7.4; python_version < \"3.8\"",
 ]
 files = [
     {file = "yarl-1.9.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a8c1df72eb746f4136fe9a2e72b0c9dc1da1cbd23b5372f94b5820ff8ae30e0e"},
@@ -1832,6 +1864,7 @@ summary = "Minimal Zope/SQLAlchemy transaction integration"
 groups = ["default"]
 dependencies = [
     "SQLAlchemy!=1.4.0,!=1.4.1,!=1.4.2,!=1.4.3,!=1.4.4,!=1.4.5,!=1.4.6,>=0.9",
+    "SQLAlchemy<1.4,>=0.9; python_version == \"3.5\"",
     "setuptools",
     "transaction>=1.6.0",
     "zope-interface>=3.6.0",


### PR DESCRIPTION
Add the ability to get list of network nodes from the AREDN JSON API instead of OLSR.

This method doesn't provide the same link information as OLSR, but that was just being used as a fallback for nodes with very old firmware.  Retiring OLSR entirely will be handled in another branch.

Fixes #132